### PR TITLE
adjust file tree appearance

### DIFF
--- a/lua/acetolyne/core/keymaps.lua
+++ b/lua/acetolyne/core/keymaps.lua
@@ -14,7 +14,8 @@ keymap.set("n", "<leader>=", "<C-x>", { desc = "Decrement number" }) -- decremen
 
 -- nvim tree mappings
 
-keymap.set("n", "<leader>tt", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle file explorer" }) -- toggle file explorer
+keymap.set("n", "<leader>t", "<cmd>NvimTreeFocus<CR>", { desc = "Open and focus file tree" }) -- toggle file explorer
+keymap.set("n", "<leader>tt", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle file tree view" }) -- toggle file explorer
 keymap.set("n", "<leader>tf", "<cmd>NvimTreeFindFileToggle<CR>", { desc = "Toggle file explorer on current file" }) -- toggle file explorer on current file
 keymap.set("n", "<leader>tc", "<cmd>NvimTreeCollapse<CR>", { desc = "Collapse file explorer" }) -- collapse file explorer
 keymap.set("n", "<leader>tr", "<cmd>NvimTreeRefresh<CR>", { desc = "Refresh file explorer" })

--- a/lua/acetolyne/plugins/nvim-tree.lua
+++ b/lua/acetolyne/plugins/nvim-tree.lua
@@ -10,8 +10,8 @@ return {
 
     nvimtree.setup({
       view = {
-        width = 35,
-        relativenumber = true,
+        width = "10%",
+        -- relativenumber = true,
       },
       -- change folder arrow icons
       renderer = {
@@ -35,10 +35,10 @@ return {
           window_picker = {
             enable = false,
           },
-          quit_on_open = true,
+          quit_on_open = false,
         },
       },
-      filters = {
+    filters = {
         custom = { ".DS_Store" },
       },
       git = {

--- a/lua/acetolyne/plugins/toggleterm.lua
+++ b/lua/acetolyne/plugins/toggleterm.lua
@@ -16,3 +16,4 @@ return {"akinsho/toggleterm.nvim", config = function()
     },
   })
 end}
+-- TODO: if possible only open toggleterm if in fullscreen else hide until hotkey is used


### PR DESCRIPTION
visual adjustments to the file tree area, also makes it stay visible when a file is opened and adds hotkey <leader>t to move focus to the file tree