### PR TITLE
update hotkey to exit terminal mode so that we can still use vim from…

### DIFF
--- a/lua/acetolyne/core/keymaps.lua
+++ b/lua/acetolyne/core/keymaps.lua
@@ -44,7 +44,7 @@ keymap.set("n", "<leader>sa", "<cmd>ToggleTermToggleAll<cr>", {desc = "Toggle vi
 -- toggle term keymaps for inside the terminal
 function _G.set_terminal_keymaps()
   local opts = {buffer = 0}
-  vim.keymap.set('t', '<esc>', [[<C-\><C-n>]], opts)
+  vim.keymap.set('t', '<C-b>', [[<C-\><C-n>]], opts)
   vim.keymap.set('t', 'jk', [[<C-\><C-n>]], opts)
   vim.keymap.set('t', '<C-h>', [[<Cmd>wincmd h<CR>]], opts)
   vim.keymap.set('t', '<C-j>', [[<Cmd>wincmd j<CR>]], opts)


### PR DESCRIPTION
There was an issue using vim in the integrated terminal, which is used by git for merges. The esc key was the mapping to exit terminal mode thus once you entered vim there was no way to exit vim as esc would exit the terminal.
This remaps the terminal exit hotkey to CTRL+b