### PR TITLE
Dev

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,6 +17,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - djlint@1.36.1
     - checkov@3.2.269
     - git-diff-check
     - prettier@3.3.3

--- a/ftdetect/tmpl.vim
+++ b/ftdetect/tmpl.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.tmpl                set filetype=htmldjango

--- a/lua/acetolyne/core/keymaps.lua
+++ b/lua/acetolyne/core/keymaps.lua
@@ -54,3 +54,6 @@ end
 
 -- if you only want these mappings for toggle term use term://*toggleterm#* instead
 vim.cmd('autocmd! TermOpen term://* lua set_terminal_keymaps()')
+
+-- hotkey to format current file
+vim.keymap.set('n', '<leader>fb', [[gg=G]], {desc = "format current buffer"}) -- lsp formatting

--- a/lua/acetolyne/plugins/init.lua
+++ b/lua/acetolyne/plugins/init.lua
@@ -1,4 +1,5 @@
 return {
   "nvim-lua/plenary.nvim", -- lua functions that many plugins use
   -- "christoomey/vim-tmux-navigator", -- tmux & split window navigation
+  vim.treesitter.language.register('template', { 'htmldjango' })
 }

--- a/lua/acetolyne/plugins/lsp/lspconfig.lua
+++ b/lua/acetolyne/plugins/lsp/lspconfig.lua
@@ -111,7 +111,7 @@ return {
         -- configure emmet language server
         lspconfig["emmet_ls"].setup({
           capabilities = capabilities,
-          filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
+          filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte", "tmpl" },
         })
       end,
       ["lua_ls"] = function()

--- a/lua/acetolyne/plugins/lsp/lspconfig.lua
+++ b/lua/acetolyne/plugins/lsp/lspconfig.lua
@@ -114,6 +114,13 @@ return {
           filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte", "tmpl" },
         })
       end,
+      ["djlint"] = function()
+        -- configure gohtml language server
+        lspconfig["djlint"].setup({
+          capabilities = capabilities,
+          filetypes = { "template", "htmldjango" },
+        })
+      end,
       ["lua_ls"] = function()
         -- configure lua server (with special settings)
         lspconfig["lua_ls"].setup({

--- a/lua/acetolyne/plugins/lsp/mason.lua
+++ b/lua/acetolyne/plugins/lsp/mason.lua
@@ -34,6 +34,7 @@ return {
         "emmet_ls",
         "pyright",
         "gopls",
+        "djlint"
       },
     })
   end,


### PR DESCRIPTION
adds fix for go html files and makes them be detected as a htmldjango file
This is the closest I have been able to get for tmpl files to have the proper formatting as well as the best to reformat indentation for the file.